### PR TITLE
Fix: xmrig first hashrate sometimes is `n/a` even though second one is valid (slow GPUs mostly)

### DIFF
--- a/mm.js
+++ b/mm.js
@@ -43,8 +43,8 @@ const AGENT        = "Meta Miner " + VERSION;
 // the nr benchmark prints is to make sure hashrate has stabilized before snapping the benchmark value
 const hashrate_regexes = [
   [1,       1, /\[[^\]]+\] speed 2.5s\/60s\/15m [\d\.]+ ([\d\.]+)\s/],       // for old xmrig
-  [1,       1, /\[[^\]]+\] speed 10s\/60s\/15m [\d\.]+ ([\d\.]+)\s/],        // for new xmrig
-  [1,       1, /\s+miner\s+speed 10s\/60s\/15m [\d\.]+ ([\d\.]+)\s/],        // for xmrig v6+
+  [1,       1, /\[[^\]]+\] speed 10s\/60s\/15m [\d\.n/a]+ ([\d\.]+)\s/],     // for new xmrig
+  [1,       1, /\s+miner\s+speed 10s\/60s\/15m [\d\.n/a]+ ([\d\.]+)\s/],     // for xmrig v6+
   [1,       1, /Totals \(ALL\):\s+[\d\.]+\s+([1-9]\d*\.\d+|0\.[1-9]\d*)\s/], // xmr-stak
   [1,       1, /Total Speed: ([\d\.]+) H\/s,/],                              // claymore
   [1,       1, /\(Avr ([\d\.]+)H\/s\)/],                                     // CryptoDredge


### PR DESCRIPTION
Added characters to the first hashrate identifier to include `n/a` along with numbers and dot.

Sometimes with slow GPU or slow CPU the hashrate system in xmrig gets confused, and doesn't show a hashrate for 10s but does  have a number for the longer 60s window.  This hashrate is valid, but the regex didn't pick it up due to no number in the 10s column.